### PR TITLE
Created the Continous Integration workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow-dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-typescript:
+    name: TypeScript Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        id: setup-node
+        uses: actions/setup-node@v4
+        with:
+          cache: npm
+
+      - name: Install Dependencies
+        id: npm-ci
+        run: npm ci
+
+      - name: Lint
+        id: npm-lint
+        run: npm run lint
+    
+      # Add a test step here later on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - main
-  workflow-dispatch:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This workflow runs a linter (eslint) in order to `find syntax errors` when either a `pull request` is created and when there is a `push` to the `main branch`.

To test it manually, you can do the following:
- Go to the `Actions` tab.
- Click on the `Continuous Integration` workflow under `All Workflows`.
- Click `Run Workflow` on the right side (you can also pick the branch by clicking the drop down arrow)

This will (almost) complete issue #4 since we still need to write some test to include them in this workflow as well